### PR TITLE
Add a mobile view handle for a size variants of some components

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -47,9 +47,9 @@ const finalClass = computed(() => {
   let cls = 'min-w-[80px] px-2 flex justify-center items-center font-medium disabled:cursor-default hover:cursor-pointer'
 
   switch (props.size) {
-    case 'xs': cls += ' h-[32px] text-xs'; break
-    case 'sm': cls += ' h-[36px] text-sm'; break
-    case 'md': cls += ' h-[40px] text-base'; break
+    case 'xs': cls += ' h-[40px] sm:h-[32px] text-sm'; break
+    case 'sm': cls += ' h-[44px] sm:h-[36px] text-sm'; break
+    case 'md': cls += ' h-[44px] sm:h-[40px] text-base'; break
     case 'lg': cls += ' h-[48px] text-base'; break
     case 'xl': cls += ' h-[52px] text-base'; break
   }

--- a/src/components/form/AutoCompleteInput.vue
+++ b/src/components/form/AutoCompleteInput.vue
@@ -79,11 +79,11 @@ const input: Ref<HTMLInputElement | null> = ref(null)
 const generateSizeClass = (): string => {
   switch (props.size) {
     case 'sm':
-      return 'text-sm h-[36px]'
+      return 'text-sm h-[40px] sm:h-[36px]'
     case 'lg':
-      return 'text-lg'
+      return 'text-lg h-[48px]'
     default:
-      return 'text-base'
+      return 'text-base h-[44px]'
   }
 }
 

--- a/src/components/form/CheckboxInput.vue
+++ b/src/components/form/CheckboxInput.vue
@@ -47,11 +47,11 @@ function handleChange(event: Event): void {
 const sizeClass = computed(() => {
   switch (props.size) {
     case 'sm':
-      return 'w-3.5 h-3.5 text-sm'
+      return 'w-4 h-4 sm:w-3.5 sm:h-3.5 text-sm'
     case 'lg':
       return 'w-5 h-5 text-lg'
     default:
-      return 'w-4 h-4 text-base'
+      return 'w-5 h-5 sm:w-4 sm:h-4 text-base'
   }
 })
 </script>

--- a/src/components/form/SelectInput.vue
+++ b/src/components/form/SelectInput.vue
@@ -39,11 +39,11 @@ const sizeClass = computed(() => {
     props.size === 'md' ? (props.small ? 'sm' : 'md') : props.size
   switch (effectiveSize) {
     case 'sm':
-      return 'h-[36px]'
+      return 'h-[42px] sm:h-[36px]'
     case 'lg':
       return 'h-[48px]'
     default:
-      return 'h-[42px]'
+      return 'h-[48px] sm:h-[42px]'
   }
 })
 </script>

--- a/src/components/form/TextInput.vue
+++ b/src/components/form/TextInput.vue
@@ -84,11 +84,11 @@ const paddingClass = computed(() => {
 const sizeClass = computed(() => {
   switch (props.size) {
     case 'sm':
-      return 'text-sm h-[36px]'
+      return 'text-sm h-[40px] sm:h-[36px]'
     case 'lg':
-      return 'text-lg'
+      return 'text-lg h-[48px]'
     default:
-      return 'text-base'
+      return 'text-base h-[44px]'
   }
 })
 </script>


### PR DESCRIPTION
# Title
Add a mobile view handle for size variants of some components

# Description

## Summary
This pull request adds a mobile view handle for the size variants of some components.

## Changes
- Add a mobile handle for the size variant of the `Button` component.
- Add a mobile handle for the size variant of the `AutoCompleteInput` component.
- Add a mobile handle for the size variant of the `CheckboxInput` component.
- Add a mobile handle for the size variant of the `SelectInput` component.
- Add a mobile handle for the size variant of the `TextInput` component.